### PR TITLE
Rename method setCacheList to pushToCacheList in RedisCache to avoid ambiguity

### DIFF
--- a/ruoyi-common/src/main/java/com/ruoyi/common/core/redis/RedisCache.java
+++ b/ruoyi-common/src/main/java/com/ruoyi/common/core/redis/RedisCache.java
@@ -136,7 +136,7 @@ public class RedisCache
      * @param dataList 待缓存的List数据
      * @return 缓存的对象
      */
-    public <T> long setCacheList(final String key, final List<T> dataList)
+    public <T> long pushToCacheList(final String key, final List<T> dataList)
     {
         Long count = redisTemplate.opsForList().rightPushAll(key, dataList);
         return count == null ? 0 : count;


### PR DESCRIPTION
## Background (背景)
The method `setCacheList` in `com.ruoyi.common.core.redis.RedisCache` is currently responsible for adding a list of values to a Redis list using `rightPushAll()`. However, the method name `setCacheList` may cause ambiguity:

1. **Potential misunderstanding of "set"**: The term `set` usually implies an overwrite operation, but `rightPushAll()` actually appends elements to the existing list in Redis.
2. **Unclear intent of "CacheList"**: It is not immediately clear whether this method replaces the list or appends to it.

To clarify the actual behavior, I propose renaming the method to `pushToCacheList`, which aligns with Redis terminology (`push`) and makes it explicit that data is being appended rather than replaced.

`com.ruoyi.common.core.redis.RedisCache` 类中的 `setCacheList` 方法使用 `rightPushAll()` 向 `Redis` 列表添加数据。但 `setCacheList` 这个方法名可能引起歧义，原因如下：

1. **"set" 可能导致误解**：通常 `set` 语义上表示“覆盖存储”，但 `rightPushAll()` 实际上是追加数据，容易让使用者误认为数据会被覆盖。
2. **"CacheList" 表意不明确**：该方法的行为是追加数据，而不是替换，方法名应当更准确地反映其功能。

为避免歧义，本 PR 将该方法重命名为 `pushToCacheList`，更符合 Redis 语义，使其行为更加清晰。

## Changes in this PR
- Rename method `setCacheList` → `pushToCacheList`
- Update all references to this method accordingly

## Impact Analysis
- **No functional changes**: This is only a method name change, the logic remains the same.
- **Potential impact on external calls**: If this method is used externally, other parts of the codebase must be updated accordingly.

## Checklist
- [x] Method name updated in `RedisCache`
- [x] Updated all relevant references
- [x] Verified functionality remains unchanged

## Additional Notes
If necessary, I can add a `@Deprecated` annotation to `setCacheList` and introduce `pushToCacheList` as a new method to ensure backward compatibility.

如果需要，我可以给 `setCacheList` 方法添加 `@Deprecated` 注解，并新增 `pushToCacheList` 方法，以保证向后兼容性。